### PR TITLE
feature(riot_driver): Initial implementation of riot driver using make

### DIFF
--- a/riot_pal/base_device.py
+++ b/riot_pal/base_device.py
@@ -40,13 +40,13 @@ class BaseDevice:
         """Closes the device connection."""
         self._driver.close()
 
-    def _read(self):
+    def _readline(self):
         """Reads data from the driver.
 
         Returns:
             str: string of data if success, driver defined error if failed.
         """
-        return self._driver.read()
+        return self._driver.readline()
 
     def _write(self, data):
         """Writes data to the driver.

--- a/riot_pal/dut_shell.py
+++ b/riot_pal/dut_shell.py
@@ -47,7 +47,7 @@ class DutShell(BaseDevice):
                 result - Either success, error or timeout.
         """
         self._write(send_cmd)
-        response = self._read()
+        response = self._readline()
         cmd_info = {'cmd': send_cmd, 'data': None}
         while response != '':
             if self.COMMAND in response:
@@ -66,7 +66,7 @@ class DutShell(BaseDevice):
                 cmd_info['msg'] = clean_msg.replace('\n', '')
                 cmd_info['result'] = self.RESULT_ERROR
                 break
-            response = self._read()
+            response = self._readline()
 
         if response == '':
             cmd_info['result'] = self.RESULT_TIMEOUT

--- a/riot_pal/ll_shell.py
+++ b/riot_pal/ll_shell.py
@@ -86,7 +86,7 @@ class LLShell(BaseDevice):
             result - Either success, error or timeout.
         """
         self._write(send_cmd)
-        data = self._read()
+        data = self._readline()
         cmd_info = {'cmd': send_cmd}
         if data == "":
             cmd_info['msg'] = "Timeout occured"

--- a/riot_pal/riot_driver.py
+++ b/riot_pal/riot_driver.py
@@ -6,25 +6,41 @@
 """RIOT Driver for RIOT PAL
 This module handles generic connection and IO to the make term.
 """
+import logging
+import os
+import pexpect
 
 
 class RiotDriver:
-    """Contains all reusable functions for connecting, sending and recieveing
+    """Contains all reusable functions for connecting, sending and receiving
     data.
-
     """
 
-    def __init__(self):
-        raise NotImplementedError()
+    def __init__(self, timeout=5, path=None):
+        if path is not None:
+            os.chdir(path)
+        self.child = pexpect.spawnu("make term", timeout=timeout,
+                                    codec_errors='replace')
 
     def close(self):
-        """Close serial connection."""
-        raise NotImplementedError()
+        """Closes the spawned process"""
+        self.child.close()
 
-    def read(self):
-        """Read and decode data."""
-        raise NotImplementedError()
+    def readline(self):
+        """Reads a line from a make term process and strips away all additional
+        data so only the output of the device is left."""
+        try:
+            response = self.child.readline()
+            response = response.split('# ', 1)[-1]
+            response = response.replace('\n', '')
+            response = response.replace('\r', '')
+        except (ValueError, TypeError, pexpect.TIMEOUT) as exc:
+            logging.debug(exc)
+            response = "ERR"
+        logging.debug("Response: %s", response)
+        return response
 
     def write(self, data):
-        """Tries write data."""
-        raise NotImplementedError()
+        """Tries write data and adds a newline."""
+        logging.debug("Writing: %s", data)
+        self.child.write(data + '\n')

--- a/riot_pal/serial_driver.py
+++ b/riot_pal/serial_driver.py
@@ -31,7 +31,7 @@ class SerialDriver:
         # Used to clear the cpu and mcu buffer from startup junk data
         time.sleep(0.1)
         self.write('')
-        self.read()
+        self.readline()
 
     def _connect(self, *args, **kwargs):
         if 'timeout' not in kwargs:
@@ -61,7 +61,7 @@ class SerialDriver:
         logging.debug("Closing %s", self._dev.port)
         self._dev.close()
 
-    def read(self):
+    def readline(self):
         """Read and decode to utf-8 data.
 
         Returns:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="riot_pal",
-    version="0.2.3",
+    version="0.2.4",
     author="RIOT OS",
     author_email="devel@riot-os.org",
     license="MIT",

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,8 +1,8 @@
 Testing a package locally
 ```
-pip uninstall riot_pal
+pip3 uninstall riot_pal
 python3 setup.py sdist
-pip install dist/riot_pal-x.x.x.tar.gz
+pip3 install dist/riot_pal-x.x.x.tar.gz
 ```
 
 Upload to pip

--- a/tests/test_serial_driver.py
+++ b/tests/test_serial_driver.py
@@ -21,7 +21,7 @@ def _open_write_read_close(regtest, *args, **kwrgs):
     try:
         ser_drvr = SerialDriver(*args, **kwrgs)
         ser_drvr.write('')
-        regtest.write(ser_drvr.read())
+        regtest.write(ser_drvr.readline())
         ser_drvr.close()
         regtest.write('SUCCESS\n')
     except (SerialException, TypeError) as exc:


### PR DESCRIPTION
This uses pexpect and the env variables to run "make term" as a driver.
It strips away any unneeded information and allows for parsing from the higher layer into a standard dictionary.