### PR TITLE
Fix(riot_pal): Fix the result, error and timeout string

### DIFF
--- a/riot_pal/dut_shell.py
+++ b/riot_pal/dut_shell.py
@@ -13,9 +13,9 @@ try:
 except ImportError:
     from base_device import BaseDevice
 
-RESULT_SUCCESS = 'SUCCESS'
-RESULT_ERROR = 'ERROR'
-RESULT_TIMEOUT = 'TIMEOUT'
+RESULT_SUCCESS = 'Success'
+RESULT_ERROR = 'Error'
+RESULT_TIMEOUT = 'Timeout'
 
 
 class ShellParser:

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="riot_pal",
-    version="0.3.0",
+    version="0.3.1",
     author="RIOT OS",
     author_email="devel@riot-os.org",
     license="MIT",
@@ -36,7 +36,7 @@ setup(
     ],
     setup_requires=["pytest-runner"],
     tests_require=["pytest", "pytest-regtest", "pprint"],
-    install_requires=['pyserial'],
+    install_requires=['pyserial', "pexpect"],
     entry_points={
         'console_scripts': ['dut_pyshell=riot_pal.dut_pyshell:main'],
     }


### PR DESCRIPTION
Currently a change of API was merged in.  This fixes the change so it will work with previous versions.  The setup version is also incremented and pexpect is added to the install list.