### PR TITLE
fix(dut_shell): Fix cmd_info initialization

### DIFF
--- a/riot_pal/dut_shell.py
+++ b/riot_pal/dut_shell.py
@@ -58,8 +58,8 @@ class ShellParser:
         self.dev._write(send_cmd)
         # pylint: disable=W0212
         try:
-            response = self.dev._readline()
             cmd_info = {'cmd': send_cmd, 'data': None}
+            response = self.dev._readline()
             while response != '':
                 if self.COMMAND in response:
                     cmd_info['msg'] = response.replace(self.COMMAND, '')

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name="riot_pal",
-    version="0.3.2",
+    version="0.3.3",
     author="RIOT OS",
     author_email="devel@riot-os.org",
     license="MIT",


### PR DESCRIPTION
If there is a read timeout on the first read then cmd_info never gets initialized and throws a incorrect exception.

This initialized before trying to read.