### PR TITLE
dut_shell: fix variable reference for timeout case

### DIFF
--- a/riot_pal/dut_shell.py
+++ b/riot_pal/dut_shell.py
@@ -57,8 +57,8 @@ class ShellParser:
         # pylint: disable=W0212
         self.dev._write(send_cmd)
         # pylint: disable=W0212
+        cmd_info = {'cmd': send_cmd, 'data': None}
         try:
-            cmd_info = {'cmd': send_cmd, 'data': None}
             response = self.dev._readline()
             while response != '':
                 if self.COMMAND in response:


### PR DESCRIPTION
This fixes a referenced before assignment exception for the variable `cmd_info` in the except block handling the command timeout.